### PR TITLE
Update README.md to mention x86_64 host requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Radxa edk2 image for cix release
 
 ## Build
 
+For the time being the build system must run on a x86_64 host due to use of CIX specific tools available in binary form, only.
+
 1. `git clone --recurse-submodules https://github.com/radxa-pkg/edk2-cix.git`
 2. Open in [`devcontainer`](https://code.visualstudio.com/docs/devcontainers/containers)
 3. `make deb`


### PR DESCRIPTION
Add a note about non-working builds on hosts other than x86_64, as reported in issue #3 